### PR TITLE
bugfix: pass meta to existsIndexTemplate method from OS API

### DIFF
--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -19,11 +19,14 @@ const BulkWriter = function BulkWriter(transport, client, options) {
   this.bulk = []; // bulk to be flushed
   this.running = false;
   this.timer = false;
+  this.connected = false;
   debug('created', this);
 };
 
 BulkWriter.prototype.start = function start() {
-  this.checkEsConnection(this.retryLimit);
+  this.checkEsConnection(this.retryLimit).finally(() => {
+    this.connected = true;
+  });
   debug('started');
 };
 
@@ -104,7 +107,7 @@ BulkWriter.prototype.append = function append(index, doc) {
       attempts: 0,
     });
     // resume the buffering process
-    if (!this.running) {
+    if (!this.running && this.connected) {
       this.running = true;
       this.tick();
     }
@@ -251,7 +254,7 @@ BulkWriter.prototype.ensureIndexTemplate = function ensureIndexTemplate(fulfill,
     name: 'template_' + templateName,
   };
   debug('Checking tpl name', tmplCheckMessage);
-  thiz.client.indices.existsIndexTemplate(tmplCheckMessage).then(
+  thiz.client.indices.existsIndexTemplate(tmplCheckMessage, { meta: true }).then(
     (res) => {
       if (res.statusCode && res.statusCode === 404) {
         const tmplMessage = {


### PR DESCRIPTION
Please see the issue from source project:  https://github.com/vanthome/winston-elasticsearch/issues/203

This is effectively a copy/paste of the solution proposed in PR: https://github.com/vanthome/winston-elasticsearch/pull/235



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced connection management for bulk writing process
- **Bug Fixes**
  - Improved connection checking mechanism with retry support
- **Chores**
  - Updated connection state tracking in bulk writing class
  - Modified bulk writing process to ensure proper state checks before execution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->