### PR TITLE
add optional dataStream boolean to OpenSearchTransportOptions interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,7 @@ export interface OpensearchTransportOptions extends TransportStream.TransportStr
   healthCheckWaitForNodes?: string;
   source?: string;
   retryLimit?: number;
+  dataStream?: boolean;
 }
 
 export class OpensearchTransport extends TransportStream {


### PR DESCRIPTION
Adds support for `dataStream` typescript interface boolean flag.

My apologies for the multiple PRs . . . please let me know if you'd prefer contributions to be made differently. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional data streaming configuration for transport options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->